### PR TITLE
The spaceless tag is deprecated

### DIFF
--- a/Resources/views/captcha.html.twig
+++ b/Resources/views/captcha.html.twig
@@ -1,13 +1,13 @@
 {% block simple_captcha_widget %}
-    {% spaceless %}
+    {% apply spaceless %}
         {{ captcha_html | raw }}
         {{ form_widget(form, { 'id': user_input_id, 'value': '' }) }}
-    {% endspaceless %}
+    {% endapply %}
 {% endblock %}
 
 {% block captcha_widget %}
-    {% spaceless %}
+    {% apply spaceless %}
         {{ captcha_html | raw }}
         {{ form_widget(form, { 'id': user_input_id, 'value': '' }) }}
-    {% endspaceless %}
+    {% endapply %}
 {% endblock %}


### PR DESCRIPTION
The spaceless tag is deprecated in Twig 2.7. Use the spaceless filter instead or {% apply spaceless %} (the Twig\Node\SpacelessNode and Twig\TokenParser\SpacelessTokenParser classes are also deprecated).